### PR TITLE
Add HLS quality selector to the player (fixes #4)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,11 @@
     <!-- Video.js JS (exposes the global `videojs` used by src/components/player/VideoPlayer.jsx) -->
     <script src="https://vjs.zencdn.net/8.6.1/video.min.js"></script>
 
+    <!-- HLS quality selector: adds a control-bar menu to switch renditions
+         (Auto + each bitrate). Reads the quality levels VHS already exposes.
+         Optional — if it fails to load, the player still works (auto quality). -->
+    <script src="https://unpkg.com/videojs-http-source-selector@1.1.6/dist/videojs-http-source-selector.min.js"></script>
+
     <!-- App entry (Vite) -->
     <script type="module" src="/src/index.js"></script>
   </body>

--- a/frontend/src/components/player/VideoPlayer.jsx
+++ b/frontend/src/components/player/VideoPlayer.jsx
@@ -61,6 +61,11 @@ function VideoPlayer({ options, token, onReady }) {
       container.appendChild(videoElement);
 
       const player = (playerRef.current = videojs(videoElement, options, () => {
+        // Add the HLS quality selector (Auto + each rendition) if the optional
+        // plugin loaded. Guarded so a missing/failed plugin never breaks playback.
+        if (typeof player.httpSourceSelector === "function") {
+          player.httpSourceSelector();
+        }
         onReady && onReady(player);
       }));
     } else {


### PR DESCRIPTION
Closes #4.

## What
Adds an optional **quality selector** to the Video.js control bar for HLS — a gear menu with **Auto** plus each available rendition.

## Where the changes are (answering the issue)
1. **`frontend/index.html`** — load the [`videojs-http-source-selector`](https://github.com/jfujita/videojs-http-source-selector) plugin via CDN (same pattern as the existing Video.js CDN script).
2. **`frontend/src/components/player/VideoPlayer.jsx`** — call `player.httpSourceSelector()` in the player ready callback, guarded by `typeof player.httpSourceSelector === "function"`.

It reads the quality levels VHS already exposes (`player.qualityLevels()` ships with Video.js 8) — **no manifest or backend changes**.

## Safety
Purely additive. The `typeof` guard means if the plugin CDN ever fails to load, the player still works (auto quality) — no crash. The token/auth flow is untouched. `npm run build` passes.

## Note on the bundled demo
The selector lists whatever renditions the manifest declares. The bundled demo is a **single-rendition** playlist, so it shows only **Auto**. Point the player at a multi-rendition **master playlist** (multiple `EXT-X-STREAM-INF` variants) to see Auto + each bitrate.